### PR TITLE
Update ScatterGL API to use an explicit call to render

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Interactive 3D / 2D webgl-accelerated scatter plot point renderer. Core function
 ```javascript
 // where `points` is an array of 2 or 3-dimensional points as number arrays.
 const dataset = new Dataset(points);
-const scatterGL = new ScatterGL(containerElement, dataset, params);
+const scatterGL = new ScatterGL();
+scatterGL.render(containerElement, dataset);
 ```
 
 ## Installation

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -40,7 +40,7 @@ let lastSelectedPoints: number[] = [];
 const containerElement = document.getElementById('container')!;
 const messagesElement = document.getElementById('messages')!;
 
-const scatterGL = new ScatterGL(containerElement, dataset, {
+const scatterGL = new ScatterGL({
   onHover: (point: number | null) => {
     const message = `🔥hover ${point}`;
     console.log(message);
@@ -62,6 +62,7 @@ const scatterGL = new ScatterGL(containerElement, dataset, {
   },
   renderMode: RenderMode.POINT,
 });
+scatterGL.render(containerElement, dataset);
 
 document
   .querySelectorAll<HTMLInputElement>('input[name="interactions"]')

--- a/src/scatter_gl.ts
+++ b/src/scatter_gl.ts
@@ -67,17 +67,26 @@ export class ScatterGL {
   private hoverCallback: (point: number | null) => void = () => {};
   private selectCallback: (points: number[]) => void = () => {};
 
-  constructor(
-    containerElement: HTMLElement,
-    dataset: Dataset,
-    params: ScatterGLParams = {}
-  ) {
-    this.containerElement = containerElement;
-    this.dataset = dataset;
+  constructor(params: ScatterGLParams = {}) {
     this.styles = makeStyles(params.styles);
 
     // Instantiate params if they exist
     this.setParameters(params);
+  }
+
+  private setParameters(p: ScatterGLParams) {
+    if (p.renderMode !== undefined) this.renderMode = p.renderMode;
+    if (p.showLabelsOnHover !== undefined)
+      this.showLabelsOnHover = p.showLabelsOnHover;
+    if (p.onHover !== undefined) this.hoverCallback = p.onHover;
+    if (p.onSelect !== undefined) this.selectCallback = p.onSelect;
+    if (p.pointColorer !== undefined) this.pointColorer = p.pointColorer;
+    if (p.rotateOnStart !== undefined) this.rotateOnStart = p.rotateOnStart;
+  }
+
+  render(containerElement: HTMLElement, dataset: Dataset) {
+    this.containerElement = containerElement;
+    this.dataset = dataset;
 
     this.scatterPlot = new ScatterPlot({
       containerElement: this.containerElement,
@@ -93,16 +102,6 @@ export class ScatterGL {
     if (this.rotateOnStart) {
       this.scatterPlot.startOrbitAnimation();
     }
-  }
-
-  private setParameters(p: ScatterGLParams) {
-    if (p.renderMode !== undefined) this.renderMode = p.renderMode;
-    if (p.showLabelsOnHover !== undefined)
-      this.showLabelsOnHover = p.showLabelsOnHover;
-    if (p.onHover !== undefined) this.hoverCallback = p.onHover;
-    if (p.onSelect !== undefined) this.selectCallback = p.onSelect;
-    if (p.pointColorer !== undefined) this.pointColorer = p.pointColorer;
-    if (p.rotateOnStart !== undefined) this.rotateOnStart = p.rotateOnStart;
   }
 
   setRenderMode(renderMode: RenderMode) {
@@ -156,10 +155,6 @@ export class ScatterGL {
 
   resize() {
     this.scatterPlot.resize();
-  }
-
-  render() {
-    this.scatterPlot.render();
   }
 
   onHover = (pointIndex: number | null) => {
@@ -568,7 +563,7 @@ export class ScatterGL {
       spriteIndices[i] = i;
     }
 
-    const onImageLoad = () => this.render();
+    const onImageLoad = () => this.scatterPlot.render();
 
     const spritesheetVisualizer = new ScatterPlotVisualizerSprites(styles, {
       spritesheetImage: spriteMetadata.spriteImage,

--- a/src/scatter_plot.ts
+++ b/src/scatter_plot.ts
@@ -143,7 +143,6 @@ export class ScatterPlot {
     this.scene.add(this.light);
 
     this.setDimensions(params.dimensions);
-    this.renderer.render(this.scene, this.camera);
 
     this.rectangleSelector = new ScatterPlotRectangleSelector(
       this.container,
@@ -553,9 +552,7 @@ export class ScatterPlot {
 
   /** Set 2d vs 3d mode. */
   setDimensions(dimensions: number) {
-    if (dimensions === this.dimensions) {
-      return;
-    }
+    if (dimensions === this.dimensions) return;
     if (dimensions !== 2 && dimensions !== 3) {
       throw new RangeError('dimensions must be 2 or 3');
     }


### PR DESCRIPTION
Now use an explicit `render` call to render a dataset to a containerElement rather than implicitly through the constructor.