### PR TITLE
Update color scheme to support opacity / occlusion

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -38,6 +38,7 @@ dataset.setSpriteMetadata({
 });
 
 let lastSelectedPoints: number[] = [];
+let renderMode = 'points';
 
 const containerElement = document.getElementById('container')!;
 const messagesElement = document.getElementById('messages')!;
@@ -82,6 +83,7 @@ document
   .querySelectorAll<HTMLInputElement>('input[name="render"]')
   .forEach(inputElement => {
     inputElement.addEventListener('change', () => {
+      renderMode = inputElement.value;
       if (inputElement.value === 'points') {
         scatterGL.setPointRenderMode();
       } else if (inputElement.value === 'sprites') {
@@ -92,10 +94,12 @@ document
     });
   });
 
-const colorsByLabel = [...new Array(10)].map((_, i) => {
-  const hue = Math.floor((255 / 10) * i);
-  return `hsl(${hue}, 100%, 50%)`;
-});
+const hues = [...new Array(10)].map((_, i) => Math.floor((255 / 10) * i));
+
+const transparentColorsByLabel = hues.map(
+  hue => `hsla(${hue}, 100%, 50%, 0.75)`
+);
+const opaqueColorsByLabel = hues.map(hue => `hsla(${hue}, 100%, 50%, 1)`);
 
 document
   .querySelectorAll<HTMLInputElement>('input[name="color"]')
@@ -106,7 +110,10 @@ document
       } else if (inputElement.value === 'label') {
         scatterGL.setPointColorer(i => {
           const labelIndex = dataset.metadata![i].labelIndex as number;
-          return colorsByLabel[labelIndex];
+          const opaque = renderMode !== 'points';
+          return opaque
+            ? opaqueColorsByLabel[labelIndex]
+            : transparentColorsByLabel[labelIndex];
         });
       }
     });

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,0 +1,47 @@
+/* Copyright 2019 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import * as THREE from 'three';
+
+export interface Color {
+  r: number;
+  g: number;
+  b: number;
+  opacity: number;
+}
+
+const cache = new Map<string, Color>();
+
+const regex = /^(rgba|hsla)\((\d+),\s*(\d+%?),\s*(\d+%?)(?:,\s*(\d+(?:\.\d+)?))?\)$/;
+
+function parseOpacity(colorString: string) {
+  const result = regex.exec(colorString);
+  if (result) {
+    const [_, rgbaOrHsla, rh, gs, bl, opacity] = result;
+    const colorString = `${rgbaOrHsla.replace('a', '')}(${rh},${gs},${bl})`;
+    return {colorString, opacity: parseFloat(opacity)};
+  }
+  return {colorString, opacity: 1};
+}
+
+export function parseColor(inputColorString: string): Color {
+  if (cache.has(inputColorString)) return cache.get(inputColorString)!;
+  const {colorString, opacity} = parseOpacity(inputColorString);
+  const color = new THREE.Color(colorString);
+  const {r, g, b} = color;
+  const item = {r, g, b, opacity};
+  cache.set(inputColorString, item);
+  return item;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 export const RGB_NUM_ELEMENTS = 3;
+export const RGBA_NUM_ELEMENTS = 4;
 export const XYZ_NUM_ELEMENTS = 3;
 export const UV_NUM_ELEMENTS = 2;
 export const INDEX_NUM_ELEMENTS = 1;

--- a/src/scatter_gl.ts
+++ b/src/scatter_gl.ts
@@ -15,12 +15,13 @@ limitations under the License.
 
 import * as THREE from 'three';
 import {ScatterPlot, CameraParams, OnCameraMoveListener} from './scatter_plot';
+import {parseColor} from './color';
 import {Dataset, Sequence} from './data';
 import {LabelRenderParams} from './render';
 import {Styles, UserStyles, makeStyles} from './styles';
 import {InteractionMode, RenderMode} from './types';
 import * as util from './util';
-import {SCATTER_PLOT_CUBE_LENGTH} from './constants';
+import {SCATTER_PLOT_CUBE_LENGTH, RGBA_NUM_ELEMENTS} from './constants';
 
 import {ScatterPlotVisualizer} from './scatter_plot_visualizer';
 import {ScatterPlotVisualizer3DLabels} from './scatter_plot_visualizer_3d_labels';
@@ -426,7 +427,7 @@ export class ScatterGL {
 
     const selectedPointCount = selectedPointIndices.length;
 
-    const colors = new Float32Array(dataset.points.length * 3);
+    const colors = new Float32Array(dataset.points.length * RGBA_NUM_ELEMENTS);
 
     let unselectedColor = colorUnselected;
     let noSelectionColor = colorNoSelection;
@@ -446,26 +447,30 @@ export class ScatterGL {
       const n = dataset.points.length;
       let dst = 0;
       if (selectedPointCount > 0) {
-        const c = new THREE.Color(unselectedColor);
+        const c = parseColor(unselectedColor);
         for (let i = 0; i < n; ++i) {
           colors[dst++] = c.r;
           colors[dst++] = c.g;
           colors[dst++] = c.b;
+          colors[dst++] = c.opacity;
         }
       } else {
         if (pointColorer) {
           for (let i = 0; i < n; ++i) {
-            const c = new THREE.Color(pointColorer(i) || noSelectionColor);
+            const c = parseColor(pointColorer(i) || noSelectionColor);
+
             colors[dst++] = c.r;
             colors[dst++] = c.g;
             colors[dst++] = c.b;
+            colors[dst++] = c.opacity;
           }
         } else {
-          const c = new THREE.Color(noSelectionColor);
+          const c = parseColor(noSelectionColor);
           for (let i = 0; i < n; ++i) {
             colors[dst++] = c.r;
             colors[dst++] = c.g;
             colors[dst++] = c.b;
+            colors[dst++] = c.opacity;
           }
         }
       }
@@ -474,22 +479,24 @@ export class ScatterGL {
     // Color the selected points.
     {
       const n = selectedPointCount;
-      const c = new THREE.Color(colorSelected);
+      const c = parseColor(colorSelected);
       for (let i = 0; i < n; ++i) {
-        let dst = selectedPointIndices[i] * 3;
+        let dst = selectedPointIndices[i] * RGBA_NUM_ELEMENTS;
         colors[dst++] = c.r;
         colors[dst++] = c.g;
         colors[dst++] = c.b;
+        colors[dst++] = c.opacity;
       }
     }
 
     // Color the hover point.
     if (hoverPointIndex != null) {
-      const c = new THREE.Color(colorHover);
-      let dst = hoverPointIndex * 3;
+      const c = parseColor(colorHover);
+      let dst = hoverPointIndex * RGBA_NUM_ELEMENTS;
       colors[dst++] = c.r;
       colors[dst++] = c.g;
       colors[dst++] = c.b;
+      colors[dst++] = c.opacity;
     }
 
     return colors;
@@ -522,8 +529,8 @@ export class ScatterGL {
 
       if (pointColorer) {
         for (let j = 0; j < sequence.indices.length - 1; j++) {
-          const c1 = new THREE.Color(pointColorer(sequence.indices[j]));
-          const c2 = new THREE.Color(pointColorer(sequence.indices[j + 1]));
+          const c1 = parseColor(pointColorer(sequence.indices[j]));
+          const c2 = parseColor(pointColorer(sequence.indices[j + 1]));
           colors[colorIndex++] = c1.r;
           colors[colorIndex++] = c1.g;
           colors[colorIndex++] = c1.b;

--- a/src/scatter_plot_visualizer_3d_labels.ts
+++ b/src/scatter_plot_visualizer_3d_labels.ts
@@ -18,7 +18,12 @@ import {ScatterPlotVisualizer} from './scatter_plot_visualizer';
 import {RenderContext} from './render';
 import {Styles} from './styles';
 import * as util from './util';
-import {RGB_NUM_ELEMENTS, UV_NUM_ELEMENTS, XYZ_NUM_ELEMENTS} from './constants';
+import {
+  RGB_NUM_ELEMENTS,
+  RGBA_NUM_ELEMENTS,
+  UV_NUM_ELEMENTS,
+  XYZ_NUM_ELEMENTS,
+} from './constants';
 
 const MAX_CANVAS_DIMENSION = 8192;
 const NUM_GLYPHS = 256;
@@ -39,9 +44,9 @@ const VERTICES_PER_GLYPH = 2 * 3; // 2 triangles, 3 verts per triangle
 
 const makeVertexShader = (fontSize: number, scale: number) => `
       attribute vec2 posObj;
-      attribute vec3 color;
+      attribute vec4 color;
       varying vec2 vUv;
-      varying vec3 vColor;
+      varying vec4 vColor;
 
       void main() {
         vUv = uv;
@@ -71,14 +76,14 @@ const FRAGMENT_SHADER = `
       uniform sampler2D texture;
       uniform bool picking;
       varying vec2 vUv;
-      varying vec3 vColor;
+      varying vec4 vColor;
 
       void main() {
         if (picking) {
-          gl_FragColor = vec4(vColor, 1.0);
+          gl_FragColor = vColor;
         } else {
           vec4 fromTexture = texture2D(texture, vUv);
-          gl_FragColor = vec4(vColor, 1.0) * fromTexture;
+          gl_FragColor = vColor * fromTexture;
         }
       }`;
 
@@ -294,7 +299,7 @@ export class ScatterPlotVisualizer3DLabels implements ScatterPlotVisualizer {
     const colors = this.geometry.getAttribute('color') as THREE.BufferAttribute;
     colors.array = this.renderColors;
 
-    const n = pointColors.length / XYZ_NUM_ELEMENTS;
+    const n = pointColors.length / RGBA_NUM_ELEMENTS;
     let src = 0;
     for (let i = 0; i < n; ++i) {
       const c = new THREE.Color(
@@ -306,7 +311,7 @@ export class ScatterPlotVisualizer3DLabels implements ScatterPlotVisualizer {
       for (let j = 0; j < m; ++j) {
         colors.setXYZ(this.labelVertexMap[i][j], c.r, c.g, c.b);
       }
-      src += RGB_NUM_ELEMENTS;
+      src += RGBA_NUM_ELEMENTS;
     }
     colors.needsUpdate = true;
   }

--- a/src/scatter_plot_visualizer_polylines.ts
+++ b/src/scatter_plot_visualizer_polylines.ts
@@ -18,7 +18,7 @@ import {ScatterPlotVisualizer} from './scatter_plot_visualizer';
 import {RenderContext} from './render';
 import {Dataset, Sequence} from './data';
 import * as util from './util';
-import {RGB_NUM_ELEMENTS, XYZ_NUM_ELEMENTS} from './constants';
+import {RGBA_NUM_ELEMENTS, XYZ_NUM_ELEMENTS} from './constants';
 
 /**
  * Renders polylines that connect multiple points in the dataset.
@@ -111,10 +111,10 @@ export class ScatterPlotVisualizerPolylines implements ScatterPlotVisualizer {
         XYZ_NUM_ELEMENTS
       );
 
-      let colors = new Float32Array(vertexCount * RGB_NUM_ELEMENTS);
+      let colors = new Float32Array(vertexCount * RGBA_NUM_ELEMENTS);
       this.polylineColorBuffer[i] = new THREE.BufferAttribute(
         colors,
-        RGB_NUM_ELEMENTS
+        RGBA_NUM_ELEMENTS
       );
     }
     for (let i = 0; i < this.sequences.length; i++) {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -135,10 +135,10 @@ const defaultStyles: Styles = {
   },
 
   point: {
-    colorUnselected: '#e3e3e3',
-    colorNoSelection: '#7575d9',
-    colorSelected: '#fa6666',
-    colorHover: '#760b4f',
+    colorUnselected: 'rgba(227, 227, 227, 0.7)',
+    colorNoSelection: 'rgba(117, 117, 217, 0.7)',
+    colorSelected: 'rgba(250, 102, 102, 0.7)',
+    colorHover: 'rgba(118, 11, 79, 0.7)',
     scaleDefault: 1.0,
     scaleSelected: 1.2,
     scaleHover: 1.2,
@@ -194,14 +194,4 @@ export function makeStyles(userStyles: UserStyles | undefined) {
     }
   }
   return defaultStyles;
-}
-
-const DEFAULT_COLOR = '#FFFFFF';
-
-export function parseColor(color: Color) {
-  if (typeof color === 'number') {
-    return;
-  } else if (typeof color === 'string') {
-  }
-  return DEFAULT_COLOR;
 }


### PR DESCRIPTION
Updates color system (adding dependency on `colors`) to support RGBA alpha values for points.

Questions - should we switch to enforcing `{ r, g, b, opacity }`  formatted objects for the the colors supplied, or try to parse a color string (knowing that opacity won't work  without the `colors` library)?