### PR TITLE
Upgrade to three.js r113

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "webpack-dev-server": "^3.4.1"
   },
   "dependencies": {
-    "three": "^0.108"
+    "three": "^0.113"
   },
   "prettier": {
     "bracketSpacing": false,

--- a/src/scatter_plot_visualizer_3d_labels.ts
+++ b/src/scatter_plot_visualizer_3d_labels.ts
@@ -225,10 +225,10 @@ export class ScatterPlotVisualizer3DLabels implements ScatterPlotVisualizer {
     let colors = new THREE.BufferAttribute(colorsArray, RGB_NUM_ELEMENTS);
 
     this.geometry = new THREE.BufferGeometry();
-    this.geometry.addAttribute('posObj', positionObject);
-    this.geometry.addAttribute('position', this.positions);
-    this.geometry.addAttribute('uv', uv);
-    this.geometry.addAttribute('color', colors);
+    this.geometry.setAttribute('posObj', positionObject);
+    this.geometry.setAttribute('position', this.positions);
+    this.geometry.setAttribute('uv', uv);
+    this.geometry.setAttribute('color', colors);
 
     let lettersSoFar = 0;
     for (let i = 0; i < pointCount; i++) {

--- a/src/scatter_plot_visualizer_sprites.ts
+++ b/src/scatter_plot_visualizer_sprites.ts
@@ -265,7 +265,7 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
     this.points = new THREE.Points(geometry, this.renderMaterial);
     this.points.frustumCulled = false;
     if (this.spriteIndexBufferAttribute != null) {
-      (this.points.geometry as THREE.BufferGeometry).addAttribute(
+      (this.points.geometry as THREE.BufferGeometry).setAttribute(
         'spriteIndex',
         this.spriteIndexBufferAttribute
       );
@@ -310,15 +310,15 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
     }
 
     const geometry = new THREE.BufferGeometry();
-    geometry.addAttribute(
+    geometry.setAttribute(
       'position',
       new THREE.BufferAttribute(new Float32Array([]), XYZ_NUM_ELEMENTS)
     );
-    geometry.addAttribute(
+    geometry.setAttribute(
       'color',
       new THREE.BufferAttribute(new Float32Array([]), RGBA_NUM_ELEMENTS)
     );
-    geometry.addAttribute(
+    geometry.setAttribute(
       'scaleFactor',
       new THREE.BufferAttribute(new Float32Array([]), INDEX_NUM_ELEMENTS)
     );
@@ -402,7 +402,7 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
     );
 
     if (this.points != null) {
-      (this.points.geometry as THREE.BufferGeometry).addAttribute(
+      (this.points.geometry as THREE.BufferGeometry).setAttribute(
         'spriteIndex',
         this.spriteIndexBufferAttribute
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5767,10 +5767,10 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-three@^0.108:
-  version "0.108.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.108.0.tgz#53d26597c7932f214bb43f4655e566d2058143b5"
-  integrity sha512-d1ysIXwi8qTlbmMwrTxi5pYiiYIflEr0e48krP0LAY8ndS8c6fkLHn6NvRT+o76/Fs9PBLxFViuI62iGVWwwlg==
+three@^0.113:
+  version "0.113.2"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.113.2.tgz#04791d491fe4359330f9dbe7b767db18bfb35d67"
+  integrity sha512-x3vrKW41/UtbWbWduWKGlfIc043SvHWr3YltehYq+UGb9YglQ2oztNGvl2eut05JtNSmP11Mh3t6Xak5/0e+Fg==
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
Upgrades to three r113 (instead of r114 https://github.com/PAIR-code/scatter-gl/pull/37) because of Google-internal version of three is pinned to 113.