### PR TITLE
Fix the warning in using ploylines

### DIFF
--- a/src/scatter_plot_visualizer_polylines.ts
+++ b/src/scatter_plot_visualizer_polylines.ts
@@ -67,8 +67,8 @@ export class ScatterPlotVisualizerPolylines implements ScatterPlotVisualizer {
 
     for (let i = 0; i < this.sequences.length; i++) {
       const geometry = new THREE.BufferGeometry();
-      geometry.addAttribute('position', this.polylinePositionBuffer[i]);
-      geometry.addAttribute('color', this.polylineColorBuffer[i]);
+      geometry.setAttribute('position', this.polylinePositionBuffer[i]);
+      geometry.setAttribute('color', this.polylineColorBuffer[i]);
 
       const material = new THREE.LineBasicMaterial({
         linewidth: 1, // unused default, overwritten by width array.


### PR DESCRIPTION
Update `addAttribute` to `setAttribute` in ploylines that was missed from #41