### PR TITLE
Update handling of sprite sheets to allow for image elements

### DIFF
--- a/src/scatter_plot_visualizer_sprites.ts
+++ b/src/scatter_plot_visualizer_sprites.ts
@@ -376,7 +376,7 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
   }
 
   private setSpriteSheet(spriteSheetParams: SpriteSheetParams) {
-    const {spriteDimensions, spriteIndices, onImageLoad} = spriteSheetParams;
+    const {spriteDimensions, onImageLoad} = spriteSheetParams;
     let spriteSheet = spriteSheetParams.spritesheetImage;
 
     // Load the sprite sheet as an image if a URL is supplied
@@ -396,6 +396,13 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
       onImageLoad();
     });
     this.spriteDimensions = spriteDimensions;
+
+    this.setSpriteIndexBuffer();
+  }
+
+  private setSpriteIndexBuffer() {
+    const {spriteIndices} = this.spriteSheetParams;
+
     this.spriteIndexBufferAttribute = new THREE.BufferAttribute(
       spriteIndices,
       INDEX_NUM_ELEMENTS
@@ -423,7 +430,7 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
     }
 
     if (this.spriteSheetParams) {
-      this.setSpriteSheet(this.spriteSheetParams);
+      this.setSpriteIndexBuffer();
     }
 
     this.renderMaterial = this.createRenderMaterial();

--- a/src/util.ts
+++ b/src/util.ts
@@ -109,10 +109,15 @@ export function createTextureFromImage(
   onImageLoad: () => void
 ): THREE.Texture {
   const texture = new THREE.Texture(image);
-  image.onload = () => {
+  if (image.complete) {
     texture.needsUpdate = true;
     onImageLoad();
-  };
+  } else {
+    image.onload = () => {
+      texture.needsUpdate = true;
+      onImageLoad();
+    };
+  }
   return prepareTexture(texture, false);
 }
 


### PR DESCRIPTION
Fixes an issue where spritesheets provided as Image elements were not being properly loaded into the three.js texture.

https://github.com/PAIR-code/scatter-gl/issues/83