### PR TITLE
Use pointer events to prevent three from eating the events

### DIFF
--- a/src/scatter_plot.ts
+++ b/src/scatter_plot.ts
@@ -187,9 +187,9 @@ export class ScatterPlot {
   }
 
   private addInteractionListeners() {
-    this.container.addEventListener('mousemove', this.onMouseMove.bind(this));
-    this.container.addEventListener('mousedown', this.onMouseDown.bind(this));
-    this.container.addEventListener('mouseup', this.onMouseUp.bind(this));
+    this.container.addEventListener('pointermove', this.onMouseMove.bind(this));
+    this.container.addEventListener('pointerdown', this.onMouseDown.bind(this));
+    this.container.addEventListener('pointerup', this.onMouseUp.bind(this));
     this.container.addEventListener('click', this.onClick.bind(this));
     window.addEventListener('keydown', this.onKeyDown.bind(this), false);
     window.addEventListener('keyup', this.onKeyUp.bind(this), false);


### PR DESCRIPTION
https://github.com/PAIR-code/scatter-gl/issues/84

See: https://github.com/mrdoob/three.js/issues/16254#issuecomment-829477230

TODO: We'll eventually want to clean up the pointer handling logic since clicks/mouse downs/ups can be a bit wonky. Probably want to add some manual drag distance / mouse down time thresholds