### PR TITLE
Allow setting of hover point to null in public API

### DIFF
--- a/src/scatter_gl.ts
+++ b/src/scatter_gl.ts
@@ -208,7 +208,7 @@ export class ScatterGL {
     return pointColorer(index, this.selectedPointIndices, this.hoverPointIndex);
   }
 
-  setHoverPointIndex(index: number) {
+  setHoverPointIndex(index: number | null) {
     this.hoverPointIndex = index;
     this.updateScatterPlotAttributes();
     /* Skip render if currently animating */


### PR DESCRIPTION
The public setHoverPointIndex would only accept a number even though internally it can also be null when clearing the hover state.