### PR TITLE
fix labels positions if space around container

### DIFF
--- a/src/scatter_gl.ts
+++ b/src/scatter_gl.ts
@@ -89,6 +89,7 @@ export class ScatterGL {
 
   constructor(containerElement: HTMLElement, params: ScatterGLParams = {}) {
     this.containerElement = containerElement;
+    this.containerElement.style.position = 'relative';
     this.styles = makeStyles(params.styles);
 
     // Instantiate params if they exist


### PR DESCRIPTION
Hello guys.

During the usage, I found a few bugs and then decided to contribute.

The first bug is the wrong label position on hover if the container has space around it.
![image](https://github.com/PAIR-code/scatter-gl/assets/910573/739405ba-69c8-479e-90b3-d5556808b0d6)

Here is the sandbox with a [reproduced bug](https://codesandbox.io/s/scatter-gl-wrong-label-positions-w7c588?file=/src/index.ts).


